### PR TITLE
Reduce FOUC (flash of unstyled content)

### DIFF
--- a/themes/hello-friend-ng/layouts/partials/extra-head.html
+++ b/themes/hello-friend-ng/layouts/partials/extra-head.html
@@ -1,0 +1,8 @@
+<style>
+  doge-nav:not(:defined) {
+    display: block;
+    overflow: hidden;
+    height: 62px;
+    opacity: 0;
+  }
+</style>


### PR DESCRIPTION
This PR implements a quick measure to remove the flash of unstyled content that is seen at the top of the page where <doge-nav> is placed.  The technique here is to apply basic layout styling (display: block, height: 62px) but have it invisible.

Ideally (and the next PR) will be to remove this statement from this project and have this styling defined within doge-web-components.