### PR TITLE
Use Doge-Web-Components initial.css

### DIFF
--- a/themes/hello-friend-ng/layouts/partials/extra-head.html
+++ b/themes/hello-friend-ng/layouts/partials/extra-head.html
@@ -1,8 +1,1 @@
-<style>
-  doge-nav:not(:defined) {
-    display: block;
-    overflow: hidden;
-    height: 62px;
-    opacity: 0;
-  }
-</style>
+<link rel="stylesheet" type="text/css" href="https://fetch.dogecoin.org/initial.css">


### PR DESCRIPTION
This PR removes the need to define the style of yet-to-be-mounted doge-web-components.
Instead, these styles are included within the references initial.css stylesheet.